### PR TITLE
Make the ipfs link actually work

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ Self study operating systems.
 - [CalTech](http://users.cms.caltech.edu/~donnie/cs124/lectures/)
 - [Notes](https://peterchen.xyz/Operating%20System/cs124/)
 - Torrent [link](p2p/caltech-cs124-operating-systems-8835f0ca640ca9405f32c7d00c140cc16fcfa078.torrent) and [info](https://academictorrents.com/details/8835f0ca640ca9405f32c7d00c140cc16fcfa078)
-- [ipfs](ipfs://QmPGj9ckvsAKxnW5wEN6QHMo21nYnftcmdzSZnHHjb5spp)
+- ipfs: ipfs://QmPGj9ckvsAKxnW5wEN6QHMo21nYnftcmdzSZnHHjb5spp
 
 ## [MIT Open Courseware 6.828 Operating Systems Engineering](https://github.com/argosopentech/operating-systems-engineering)


### PR DESCRIPTION
For some reason GitHub won't show the link using markdown